### PR TITLE
refactor:  WeeklyInsightController 응답 형식 표준화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,8 @@ jobs:
             -Dspring.datasource.username=${{ secrets.DB_USERNAME }} \
             -Dspring.datasource.password=${{ secrets.DB_PASSWORD }} \
             -DJWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }} \
+            -DJWT_ACCESS_EXPIRATION=${{ vars.JWT_ACCESS_EXPIRATION }} \
+            -DJWT_REFRESH_EXPIRATION=${{ vars.JWT_REFRESH_EXPIRATION }} \
             -DOPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} \
             ~/habiglow-0.0.1-SNAPSHOT.jar > ~/nohup.out 2>&1 &
           

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/controller/WeeklyInsightController.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/controller/WeeklyInsightController.java
@@ -2,6 +2,8 @@ package com.groomthon.habiglow.domain.dashboard.controller;
 
 import com.groomthon.habiglow.domain.dashboard.dto.WeeklyInsightDto;
 import com.groomthon.habiglow.domain.dashboard.service.WeeklyInsightService;
+import com.groomthon.habiglow.global.dto.CommonApiResponse;
+import com.groomthon.habiglow.global.response.ApiSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -13,7 +15,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -39,7 +40,7 @@ public class WeeklyInsightController {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @GetMapping("/insight")
-    public ResponseEntity<WeeklyInsightDto> getInsight(
+    public CommonApiResponse<WeeklyInsightDto> getInsight(
             @Parameter(name = "weekStart", description = "주 시작일(월요일)", required = true, example = "2025-08-25", in = ParameterIn.QUERY)
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart,
             @Parameter(name = "force", description = "기존 저장이 있어도 재생성 여부", example = "false", in = ParameterIn.QUERY)
@@ -47,7 +48,8 @@ public class WeeklyInsightController {
             @Parameter(name = "memberId", description = "대상 사용자 ID (예: 더미는 1)", required = true, example = "1", in = ParameterIn.QUERY)
             @RequestParam Long memberId
     ) {
-        return ResponseEntity.ok(service.getOrCreate(memberId, weekStart, force));
+        var dto = service.getOrCreate(memberId, weekStart, force);
+        return CommonApiResponse.success(ApiSuccessCode.SUCCESS, dto);
     }
 
     @Operation(
@@ -62,12 +64,13 @@ public class WeeklyInsightController {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @GetMapping("/insight/last-week")
-    public ResponseEntity<WeeklyInsightDto> getLastWeekInsight(
+    public CommonApiResponse<WeeklyInsightDto> getLastWeekInsight(
             @Parameter(name = "force", description = "기존 저장이 있어도 재생성 여부", example = "false", in = ParameterIn.QUERY)
             @RequestParam(defaultValue = "false") boolean force,
             @Parameter(name = "memberId", description = "대상 사용자 ID (예: 더미는 1)", required = true, example = "1", in = ParameterIn.QUERY)
             @RequestParam Long memberId
     ) {
-        return ResponseEntity.ok(service.getLastWeekOrCreate(memberId, force));
+        var dto = service.getLastWeekOrCreate(memberId, force);
+        return CommonApiResponse.success(ApiSuccessCode.SUCCESS, dto);
     }
 }

--- a/src/main/java/com/groomthon/habiglow/global/config/SwaggerConfig.java
+++ b/src/main/java/com/groomthon/habiglow/global/config/SwaggerConfig.java
@@ -43,8 +43,8 @@ import io.swagger.v3.oas.models.servers.Server;
 		description = "JWT 인증 기반 로그인 시스템의 REST API 문서입니다.",
 		version = "v1.0.0",
 		contact = @Contact(
-			name = "김규일",
-			email = "rlarbdlf222@gmail.com",
+			name = "김규일, 홍성민",
+			email = "rlarbdlf222@gmail.com, hskhsmmm@gmail.com",
 			url = "https://github.com/Kimgyuilli"
 		),
 		license = @License(


### PR DESCRIPTION

  - WeeklyInsightController가 CommonApiResponse 래퍼를 사용하도록 변경

  - CommonApiResponse 및 ApiSuccessCode import 추가

  - /insight와 /insight/last-week 엔드포인트 모두 업데이트

  - WeeklyDashboardController와 일관된 응답 형식으로 통일

  - 프론트엔드 API 연동 호환성 문제 해결

