### PR TITLE
fix: 대시보드 감정 분포 통계를 실제 EmotionType과 일치하도록 수정

### DIFF
--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyDashboardService.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyDashboardService.java
@@ -261,23 +261,12 @@ public class WeeklyDashboardService {
         return (desc != null && !desc.isBlank()) ? desc : c.name();
     }
 
-    private static String emojiToMoodName(String emoji) {
-        if (emoji == null) return null;
-        return switch (emoji) {
-            case "🙂", "😊", "😀" -> "HAPPY";
-            case "😐", "😶" -> "SOSO";
-            case "☹️", "🙁", "😢" -> "SAD";
-            case "😡", "😠" -> "MAD";
-            default -> "SOSO";
-        };
-    }
-
     private static Map<String, Integer> buildEmotionDistribution(List<DailyCompletionInfo> daily) {
         Map<String, Integer> dist = new LinkedHashMap<>();
-        dist.put("HAPPY", 0);
-        dist.put("SOSO", 0);
-        dist.put("SAD", 0);
-        dist.put("MAD", 0);
+        dist.put("LOW", 0);
+        dist.put("NORMAL", 0);
+        dist.put("GOOD", 0);
+        dist.put("VERY_GOOD", 0);
         for (var d : daily) {
             if (d.isFuture()) continue;
             if (d.getMood() == null) continue;

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyDashboardService.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyDashboardService.java
@@ -186,7 +186,7 @@ public class WeeklyDashboardService {
                         .done(done)
                         .total(total)
                         .rate(rate)
-                        .mood(emojiToMoodName(day.getMood()))
+                        .mood(day.getMood()) // 직접 사용 (이미 EmotionType.name() 형태)
                         .isFuture(false)
                         .build());
 


### PR DESCRIPTION
**기존 (잘못된 값들)**:
  - `HAPPY`, `SOSO`, `SAD`, `MAD`

  **실제 EmotionType**:
  - `LOW` (25%), `NORMAL` (50%), `GOOD` (75%), `VERY_GOOD` (100%)

  ## 수정 내용
  - `WeeklyDashboardService.buildEmotionDistribution()` 메서드 수정
  - 감정 분포 키를 실제 `EmotionType` enum 값으로 변경
  - 퍼센트 기반 감정 측정 시스템과 일치하도록 통합
